### PR TITLE
feature: Add contracts code that make RLUSD work

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Initializable} from "node_modules/@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ContextUpgradeable} from "node_modules/@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+
+/**
+ * @dev The following contract lets us halt activities for accounts that have been paused using the
+ * `_pauseAccount` method and the same action can be reverted by using the `_unpauseAccount`
+ * method. The state is stored at a custom storage location as per ERC7201. The modifiers in this
+ * contract are used in the base `StablecoinUpgradeable` contract resulting in blocked actions for
+ * specific accounts.
+ *
+ * @custom:security-contact bugs@ripple.com
+ */
+abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeable {
+    /// @custom:storage-location erc7201:storage.AccountPausable
+    struct AccountPausableStorage {
+        mapping(address account => bool) _frozen;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("storage.AccountPausable")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant AccountPausableStorageLocation = 0x345cc2404af916c3db112e7a6103770647a90ed78a5d681e21dc2e1174232900;
+
+    function _getAccountPausableStorage() private pure returns (AccountPausableStorage storage $) {
+        assembly {
+            $.slot := AccountPausableStorageLocation
+        }
+    }
+
+    /**
+     * This event is emitted when an account is paused in the contract.
+     */
+    event AccountPaused(address account);
+    /**
+     * This event is emitted when an account is unpaused in the contract.
+     */
+    event AccountUnpaused(address account);
+
+    error AccountIsPaused(address account);
+    error AccountIsNotPaused(address account);
+
+    function __AccountPausable_init() internal onlyInitializing {
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the account is not paused.
+     *
+     * Requirements:
+     * - The account must not already be paused.
+     */
+    modifier whenAccountNotPaused(address account) {
+        if (accountPaused(account)) {
+            revert AccountIsPaused(account);
+        }
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the acoount is paused.
+     *
+     * Requirements:
+     * - The account must already be paused.
+     */
+    modifier whenAccountPaused(address account) {
+        if (!accountPaused(account)) {
+            revert AccountIsNotPaused(account);
+        }
+        _;
+    }
+
+    /**
+     * @notice Check if an address is paused in the contract.
+     *
+     * @param account The `address` to check the pause status of.
+     *
+     * @return Boolean to indicate if an account is paused or not.
+     */
+    function accountPaused(address account) public view virtual returns (bool) {
+        AccountPausableStorage storage $ = _getAccountPausableStorage();
+        return $._frozen[account];
+    }
+
+    /**
+     * @dev Pauses an account from circulating the ERC20 token.
+     *
+     * Requirements:
+     * - The account must not be paused.
+     */
+    function _pauseAccount(address account) internal virtual whenAccountNotPaused(account) {
+        AccountPausableStorage storage $ = _getAccountPausableStorage();
+        $._frozen[account] = true;
+        emit AccountPaused(account);
+    }
+
+    /**
+     * @dev Returns account to normal state.
+     *
+     * Requirements:
+     * - The account must be paused.
+     */
+    function _unpauseAccount(address account) internal virtual whenAccountPaused(account) {
+        AccountPausableStorage storage $ = _getAccountPausableStorage();
+        $._frozen[account] = false;
+        emit AccountUnpaused(account);
+    }
+}

--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ECDSA} from "node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @dev This is an implementation of an on-chain multi-sign. On-chain multi-sign ensures that a quorum of signatures
+ * needs to be submitted before the transaction is passed on to the ERC20 contract(in our case). To verify signatures
+ * and hash data in a particular way, we use the EIP712.sol scheme: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md.
+ *
+ * @custom:security-contact bugs@ripple.com
+ */
+contract MultiSign {
+
+    //keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)")
+    bytes32 constant public EIP712DOMAIN_TYPEHASH = 0xd87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472;
+
+    //keccak256("MultiSignTransaction(address destination,bytes data,uint256 nonce,address executor,uint256 gasLimit)")
+    bytes32 constant public MULTISIGN_TYPEHASH = 0xb8dc02dde922989f2f9c331431088d8b7e24696ed816c001c5b82192a1c91a8f;
+
+    //randomly generated salt
+    bytes32 constant public SALT = 0x55c2a1c584c6a7013cb797a4622f427c630274bf9e8d9ec26ab9015ddaabcb33;
+
+    //keccak256("MultiSign")
+    bytes32 constant public NAME_HASH = 0xa2743967920baf970a18574423a5e903484167f01ff6c1b931ebc9e87d7792b9;
+
+    // keccak256("1")
+    bytes32 constant public VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
+
+    bytes32 private immutable DOMAIN_SEPARATOR;
+
+    /**
+     * A state variable to store the total weight of all signatures required to successfully finish
+     * execution of the `execute` method.
+     */
+    uint256 public quorum;
+    /**
+     * Every transaction submitted to this contract should have a nonce associated to it just like
+     * any other EOA or Contract Account. This state variable holds that value.
+     */
+    uint256 public nonce;
+    address[] private signersArr;
+    mapping (address => bool) private isSigner;
+    mapping (address => uint8) private weights;
+
+    /**
+     * @dev Event emitted when the state of the contract changes.
+     *
+     * @param account The contract for which the signer information was updated, which is this.
+     * @param signers The new array of signer address.
+     * @param weights The new array of weights of the signers.
+     * @param quorum  The cumulative weight of all signatures should exceed or match this value.
+     */
+    event SignersChanged(address account, address[] signers, uint8[] weights, uint256 quorum);
+
+    /**
+     * @dev Event emitted when the destination contract is called with the provided calldata.
+     *
+     * @param destination The contract being called with the provided calldata.
+     * @param data        The encoded bytes that will lead to execution of a method and change state of the destination
+     *                    contract.
+     * @param gasLimit    The maximum amount of gas that can be consumed by the destination contract to execute the
+     *                    calldata.
+     */
+    event DestinationCalled(address destination, bytes data, uint256 gasLimit);
+
+    /**
+    * Default constructor to initialize the MultiSign contract.
+    * Signer addresses submitted to the contract should be ordered by their string values.
+    **/
+    constructor (address[] memory _signers, uint8[] memory _weights, uint256 _quorum) {
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712DOMAIN_TYPEHASH,
+            NAME_HASH,
+            VERSION_HASH,
+            block.chainid,
+            address(this),
+            SALT
+        ));
+
+        setSigners_(_signers, _weights, _quorum);
+        emit SignersChanged(address(this), _signers, _weights, _quorum);
+    }
+
+    /**
+     * @dev Returns the list of signer addresses in an array.
+     */
+    function signers() external view returns (address[] memory) {
+        return signersArr;
+    }
+
+    /**
+     * @dev Given an address of a signer, return the weight of it's signature that gets counted
+     * for this account.
+     */
+    function signerWeight(address signer) external view returns (uint8) {
+        return weights[signer];
+    }
+
+    // Note that signers_ must be strictly increasing, in order to prevent duplicates
+    function setSigners_(address[] memory _signers, uint8[] memory _weights, uint256 _quorum) private {
+        require(_signers.length <= 32, "Contract allows adding up to 32 signers only.");
+        require(_quorum > 0, "Quorum cannot be 0.");
+
+        // remove old signers from map and set weights to 0
+        uint256 existingSignerArrLength = signersArr.length;
+        for (uint256 i = 0; i < existingSignerArrLength; ++i) {
+            isSigner[signersArr[i]] = false;
+            weights[signersArr[i]] = 0;
+        }
+
+        // add new signers to map
+        uint256 signatureWeights = 0;
+        address lastAdd = address(0);
+        uint256 newSignerArrLength = _signers.length;
+        for (uint256 i = 0; i < newSignerArrLength; ++i) {
+            require(_signers[i] > lastAdd, "Addresses should be sorted");
+            isSigner[_signers[i]] = true;
+            weights[_signers[i]] = _weights[i];
+            signatureWeights += _weights[i];
+            lastAdd = _signers[i];
+        }
+        require(_quorum <= signatureWeights, "Quorum must be less than or equal to sum of all signer weights");
+
+        // set signers array and quorum
+        signersArr = _signers;
+        quorum = _quorum;
+    }
+
+    /**
+     * @dev This method facilitates changing the signer addresses, their weights and quorum. Since
+     * this method changes the state of the contract, it emits the `SignersChanged` event at the
+     * end of successful execution.
+     * This method can be called by this contract only in order to verify that the signatures are
+     * from existing signers with privilege to do so.
+     */
+    function setSigners(address[] memory _signers, uint8[] memory _weights, uint256 _quorum) external {
+        require(msg.sender == address(this), "Only this contract can set signers after signature verification");
+        setSigners_(_signers, _weights, _quorum);
+        emit SignersChanged(address(this), _signers, _weights, _quorum);
+    }
+
+    /**
+     * @dev This method is called by an EOA/funding account with the correct set of signatures to eventually
+     * make a call to the `destination` with provided call data.
+     * Example, calls to the ERC20 contract are made from this method for all MultiSign accounts.
+     */
+    function execute(
+        uint8[] memory sigV, bytes32[] memory sigR, bytes32[] memory sigS, address executor, address destination,
+        uint256 gasLimit, bytes calldata data
+    ) external {
+
+        require(sigR.length == sigS.length && sigR.length == sigV.length, "Length of signature arrays dont match.");
+        require(executor == msg.sender, "Executor has to be the sender");
+
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            keccak256(abi.encode(
+                MULTISIGN_TYPEHASH,
+                destination,
+                keccak256(data),
+                nonce,
+                executor,
+                gasLimit
+            ))
+        ));
+
+        uint256 signatureWeights = 0;
+        address lastAdd = address(0); // cannot have address(0) as an owner
+        uint256 signaturesLength = sigV.length;
+        for (uint256 i = 0; i < signaturesLength; ++i) {
+            address recovered = ECDSA.recover(digest, sigV[i], sigR[i], sigS[i]);
+            require(recovered > lastAdd, "Signatures are out of order.");
+            require(isSigner[recovered], "Address recovered from signature is not a signer.");
+            lastAdd = recovered;
+            signatureWeights += weights[recovered];
+        }
+        require(signatureWeights >= quorum, "Signature weights don't add up to the required quorum");
+
+        // If we make it here all signatures are accounted for.
+        nonce = nonce + 1;
+
+        require(destination.code.length > 0, "Destination address should be a contract address");
+
+        bool success = false;
+        (success,) = destination.call{gas: gasLimit}(data);
+        emit DestinationCalled(destination, data, gasLimit);
+        require(success, "Submission to destination failed");
+    }
+}

--- a/contracts/StablecoinProxy.sol
+++ b/contracts/StablecoinProxy.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ERC1967Proxy} from "node_modules/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * @dev Proxy to interact with {StablecoinUpgradeable}.
+ *
+ * @custom:security-contact bugs@ripple.com
+ **/
+contract StablecoinProxy is ERC1967Proxy {
+
+    constructor (address _delegate, bytes memory _data)  ERC1967Proxy(_delegate, _data)  {
+    }
+
+    /**
+     * @dev Returns the implementation address of the contract that executes a transaction.
+     */
+    function getImplementation() public view returns (address) {
+        return _implementation();
+    }
+
+}

--- a/contracts/StablecoinUpgradeable.sol
+++ b/contracts/StablecoinUpgradeable.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ERC20Upgradeable} from "node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {Initializable} from "node_modules/@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "node_modules/@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "node_modules/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {ERC20PausableUpgradeable} from "node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PausableUpgradeable.sol";
+import {AccountPausableUpgradeable} from "./AccountPausableUpgradeable.sol";
+
+/**
+ * @dev The ERC20 implementation with features to pause accounts and contracts, upgrade the implementation
+ * of this contract, assign/revoke roles and control access to specific actions in the contract and only
+ * lets this contract be initialized once.
+ *
+ * @custom:security-contact bugs@ripple.com
+ */
+contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeable, AccessControlUpgradeable,
+    ERC20PausableUpgradeable, AccountPausableUpgradeable {
+
+    //keccak256("MINTER")
+    bytes32 constant public MINTER_ROLE = 0xf0887ba65ee2024ea881d91b74c2450ef19e1557f03bed3ea9f16b037cbe2dc9;
+    //keccak256("UPGRADER")
+    bytes32 constant public UPGRADER_ROLE = 0xa615a8afb6fffcb8c6809ac0997b5c9c12b8cc97651150f14c8f6203168cff4c;
+    //keccak256("PAUSER")
+    bytes32 constant public PAUSER_ROLE = 0x539440820030c4994db4e31b6b800deafd503688728f932addfe7a410515c14c;
+    //keccak256("BURNER")
+    bytes32 constant public BURNER_ROLE = 0x9667e80708b6eeeb0053fa0cca44e028ff548e2a9f029edfeac87c118b08b7c8;
+    //keccak256("CLAWBACKER")
+    bytes32 constant public CLAWBACKER_ROLE = 0x715bacafb7a853b9b91b59ae724920a9eb0c006c5b318ac393fa1bc8974edd98;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev This method is used to initialize the contract with values that we want to use to bootstrap and run things.
+     * The modifier initializer here helps us block initialization in the constructor so that we initialize value only
+     * when deploying the proxy and not the contract itself. The initializer also tracks how many times this method is
+     * called and it can only be called once.
+     */
+    function initialize(string memory name_, string memory symbol_, address minter_, address admin_, address upgrader_,
+                        address pauser_, address clawbacker_)
+        public initializer
+    {
+        __ERC20_init(name_, symbol_);
+        __UUPSUpgradeable_init();
+        __AccessControl_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+        _grantRole(MINTER_ROLE, minter_);
+        _grantRole(UPGRADER_ROLE, upgrader_);
+        __ERC20Pausable_init();
+        __AccountPausable_init();
+        _grantRole(PAUSER_ROLE, pauser_);
+        _grantRole(CLAWBACKER_ROLE, clawbacker_);
+    }
+
+
+    /**
+     * @dev Creates a `value` amount of tokens and assigns them to `to`, by transferring it from address(0).
+     * Relies on the `_update` mechanism
+     *
+     * @param to    The address that will be receiving the minted amount.
+     * @param value The amount of tokens that are being minted to the account.
+     *
+     * Emits a {Transfer} event with `source` set to the zero address.
+     */
+    function mint(address to, uint256 value) public virtual onlyRole(MINTER_ROLE) {
+        _mint(to, value);
+    }
+
+    /**
+     * @dev Destroys a `value` amount of tokens from `msg.sender`, lowering the total supply.
+     * Relies on the `_update` mechanism.
+     *
+     * @param value The amount of tokens that are being burned from message sender's holdings.
+     *
+     * Emits a {Transfer} event with `destination` set to the zero address.
+     */
+    function burn(uint256 value) public virtual onlyRole(BURNER_ROLE) {
+        _burn(msg.sender, value);
+    }
+
+    /**
+     * @dev Destroys a `value` amount of tokens from `from` account, lowering the total supply.
+     * Relies on the `_update` mechanism.
+     *
+     * @param from  The address from which the tokens will be burned.
+     * @param value The amount of tokens that will be burned.
+     *
+     * Emits a {Transfer} event with `destination` set to the zero address.
+     */
+    function clawback(address from, uint256 value) public virtual onlyRole(CLAWBACKER_ROLE) {
+        _burn(from, value);
+    }
+
+    /**
+     * Allow an authorized minter to pause the circulation of ERC20 tokens from all accounts.
+     *
+     * Requirements:
+     * - The contract must not be paused.
+     */
+    function pause() public virtual onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * Allow an authorized minter to resume/unpause the circulation of ERC20 tokens from all account.
+     *
+     * Requirements:
+     * - The contract must be paused.
+     */
+    function unpause() public virtual onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /**
+     * Allow an authorized minter to pause the circulation of ERC20 tokens from a specified account.
+     *
+     * @param accounts An array of addresses that will be paused, restricting them from taking any value moving actions.
+     *
+     * Requirements:
+     * - accounts in the {accounts} list should be unpaused
+     */
+    function pauseAccounts(address[] calldata accounts) public virtual onlyRole(PAUSER_ROLE) {
+        address lastAdd = address(0);
+        uint256 accountsLength = accounts.length;
+        for (uint256 i = 0; i < accountsLength; ++i) {
+            require(accounts[i] > lastAdd, "Addresses should be sorted");
+            _pauseAccount(accounts[i]);
+            lastAdd = accounts[i];
+        }
+    }
+
+    /**
+     * Allow an authorized minter to resume/unpause the circulation of ERC20 tokens from a specified account.
+     *
+     * @param account The address that is being unpaused.
+     *
+     * Requirements:
+     * - the {account} should be paused
+     */
+    function unpauseAccount(address account) public virtual onlyRole(PAUSER_ROLE) {
+        _unpauseAccount(account);
+    }
+
+    /**
+     * An overridden method from {UUPSUpgradeable} which defines the permissions for authorizing an upgrade to a
+     * new implementation.
+     */
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(UPGRADER_ROLE) {}
+
+    /**
+     * An overridden method to add modifiers to check if the accounts being used to transfer are not frozen.
+     *
+     * Requirements:
+     * - the {from} account should not be paused/frozen
+     * - the {to} account should not be paused/frozen
+     * - the {msg.sender} account should not be paused/frozen
+     */
+    function _update(address from, address to, uint256 value) internal override(ERC20Upgradeable, ERC20PausableUpgradeable)
+        whenAccountNotPaused(from)
+        whenAccountNotPaused(to)
+        whenAccountNotPaused(_msgSender())
+    {
+        ERC20PausableUpgradeable._update(from, to, value);
+    }
+
+    /**
+     * An overridden method to block approvals when contract or accounts are paused.
+     *
+     * @param spender The account being approved by message sender to spend from their holdings.
+     * @param value   The number of tokens the spender is being allowed to spend.
+     *
+     * @return A boolean indicating if the approval was successful or not.
+     */
+    function approve(address spender, uint256 value) public virtual override(ERC20Upgradeable)
+        whenAccountNotPaused(spender)
+        whenAccountNotPaused(_msgSender())
+        whenNotPaused
+        returns (bool)
+    {
+        return super.approve(spender, value);
+    }
+}


### PR DESCRIPTION
## Context of Change

This PR adds the solidity code of the contracts that get deployed on the blockchain and are used for RLUSD.

1. `AccountPausableUpgradeable`: The Openzeppelin implementation of PausableUpgradeable does not provide with pausing activities for an individual account or a set of accounts. We introduce a contract that helps us pause a set of accounts.

2. `StablecoinUpgradeable`: Reference the core Openzeppelin ERC20Upgradeable contract along with AccessControlUpgradeable, UUPSUpgradeable and PausableUpgradeable. We've also add other convenient methods on top of existing ones like `mint`, `burn` and `clawback` to put in additional permissions and not access the `transfer(to, from, value)` directly for these sensitive functionalities. We also block approvals when either the contract is paused or the account involved in that approval is paused.

3. `StablecoinProxy`: To introduce changes to our ERC20 implementation or fix bugs, we have a proxy in front of it. This will help us facilitate an upgrade by delegating calls to the correct implementation contract and the role check on the method `_authorizeUpgrade` in `StablecoinUpgradeable` will help us control who gets to upgrade the contract.

4. `MultiSign`: An on-chain implementation of using a combination of private keys to sign/approve on single transaction. And each signer has a weight associated to its signature and to get a transaction going the quorum must be met. The contract also keeps track of a nonce and increments it with each successful destination call and execution.