### PR TITLE
Add _tryPauseAccount idempotent method to AccountPausableUpgradeable

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -94,6 +94,17 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
     }
 
     /**
+     * @dev Pauses an account from circulating the ERC20 token. And if the account is already paused, we don't revert.
+     */
+    function _tryPauseAccount(address account) internal virtual {
+        AccountPausableStorage storage $ = _getAccountPausableStorage();
+        if (!$._frozen[account]) {
+            $._frozen[account] = true;
+            emit AccountPaused(account);
+        }
+    }
+
+    /**
      * @dev Returns account to normal state.
      *
      * Requirements:


### PR DESCRIPTION
This adds the _tryPauseAccount method which provides an idempotent way to pause accounts without reverting if the account is already paused.

This method is used by StablecoinUpgradeableV2 to allow calling pauseAccounts multiple times on the same account without errors.

The original _pauseAccount method is kept for backward compatibility and will revert if called on an already-paused account.