### PR TITLE
fix(multisign): L-01 require signer and weight arrays to have equal length

### DIFF
--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -99,6 +99,7 @@ contract MultiSign {
 
     // Note that signers_ must be strictly increasing, in order to prevent duplicates
     function setSigners_(address[] memory _signers, uint8[] memory _weights, uint256 _quorum) private {
+        require(_signers.length == _weights.length, "Signers and weights arrays must have the same length.");
         require(_signers.length <= 32, "Contract allows adding up to 32 signers only.");
         require(_quorum > 0, "Quorum cannot be 0.");
 


### PR DESCRIPTION
## Audit finding L-01 — Signer and Weight Array Lengths Are Not Compared

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: low)

### Problem
`MultiSign.setSigners_` correlates `_signers[i]` with `_weights[i]` positionally but never compared the two array lengths:
- A `_weights` array shorter than `_signers` reverted with an out-of-bounds panic rather than a descriptive error.
- A longer `_weights` array was silently accepted; the surplus entries were ignored but still appeared in the emitted `SignersChanged` event, so off-chain consumers recorded weights that were never applied.

### Fix
Add `require(_signers.length == _weights.length, ...)` at the start of `setSigners_`, so both the constructor and `setSigners` reject mismatched inputs with a clear error.

### Notes
- No behavior change for correct (equal-length) inputs.
- **Stacked PR (1/3).** Base: `main`. L-02 and L-03 PRs are stacked on top of this branch.
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/54

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author