### PR TITLE
fix(proxy): L-02 rename constructor param to avoid shadowing inherited _delegate

### DIFF
--- a/contracts/StablecoinProxy.sol
+++ b/contracts/StablecoinProxy.sol
@@ -10,7 +10,7 @@ import {ERC1967Proxy} from "node_modules/@openzeppelin/contracts/proxy/ERC1967/E
  **/
 contract StablecoinProxy is ERC1967Proxy {
 
-    constructor (address _delegate, bytes memory _data)  ERC1967Proxy(_delegate, _data)  {
+    constructor (address implementation, bytes memory _data)  ERC1967Proxy(implementation, _data)  {
     }
 
     /**


### PR DESCRIPTION
## Audit finding L-02 — Proxy Declarations Reserve an Implementation Selector and Shadow an Inherited Function

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: low)

### Problem
The `StablecoinProxy` constructor named its first parameter `_delegate`, which shadows the inherited `Proxy._delegate` function that performs the `delegatecall`. No incorrect behavior results today (the constructor body is empty), but the shadowing is a maintainability hazard.

### Fix
Rename the constructor parameter `_delegate` → `implementation`, matching `ERC1967Proxy`, so the identifier no longer collides with an inherited member.

### Scope decision on getImplementation
The finding also notes that `getImplementation` reserves selector `0xaaf10f42` and suggests it could be removed. **It is intentionally retained** here because:
- It is relied upon by off-chain tooling.
- Removing it is a breaking ABI change disproportionate to a low-severity finding with no current impact.
- The finding explicitly sanctions retaining it.

### Notes
- **Stacked PR (2/3).** Base: `audit08-L01-signer-weight-length` (L-01 / #16). Retarget to `main` once L-01 merges.
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/55

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author