### PR TITLE
fix(v2): L-03 guard reinitialize so it only runs on a V1-initialized proxy

### DIFF
--- a/contracts/StablecoinUpgradeableV2.sol
+++ b/contracts/StablecoinUpgradeableV2.sol
@@ -28,13 +28,20 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
         _;
     }
 
+    modifier _onlyInitializedV1() {
+        if (_getInitializedVersion() != 1) {
+            revert Initializable.InvalidInitialization();
+        }
+        _;
+    }
+
     /**
      * @dev This method is used to re-initialize the contract with values that we want to use to bootstrap and run things.
      * The modifier reinitializer here helps us block initialization in the constructor so that we initialize value only
      * when deploying the proxy and not the contract itself. The reinitializer also tracks how many times this method is
      * called and it can only be called once.
      */
-    function reinitialize() external reinitializer(2) {
+    function reinitialize() external _onlyInitializedV1 reinitializer(2) {
         __ERC20Permit_init(name());
     }
 


### PR DESCRIPTION
## Audit finding L-03 — Fresh Proxy Deployments Can Be Bricked by Front-Running `reinitialize`

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: low)

### Problem
`StablecoinUpgradeableV2.reinitialize()` shared the `reinitializer(2)` modifier but had no assertion on the current initialized version and no access control. On a proxy that had not yet been initialized, anyone could call `reinitialize` first: the version advanced to 2 and `initialize` reverted permanently, leaving a proxy with no name, no symbol, and no role holder — unrecoverable.

### Fix
Add an `_onlyInitializedV1` modifier (mirroring the existing `_onlyUninitialized`) that requires `_getInitializedVersion() == 1`, and apply it to `reinitialize()`. This ensures `reinitialize` only runs as part of a genuine V1 → V2 upgrade and cannot brick a fresh proxy.

### Notes
- **Stacked PR (3/3).** Base: `audit08-L02-proxy-param-rename` (L-02 / #17). Retarget toward `main` as the stack merges down.
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/56

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author