### PR TITLE
refactor: N-08 invert clawback empty-if and add AccountPausable unchained init

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -41,6 +41,10 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
     error AccountIsNotPaused(address account);
 
     function __AccountPausable_init() internal onlyInitializing {
+        __AccountPausable_init_unchained();
+    }
+
+    function __AccountPausable_init_unchained() internal onlyInitializing {
     }
 
     /**

--- a/contracts/StablecoinUpgradeableV2.sol
+++ b/contracts/StablecoinUpgradeableV2.sol
@@ -87,9 +87,8 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
         whenAccountNotPaused(to)
         whenAccountNotPaused(_msgSender())
     {
-        if (to == address(0) && from != _msgSender()) {
-            // allow burn when account is frozen (clawback)
-        } else {
+        // Clawback burns (to == 0, caller is not the frozen account) skip the from-paused check.
+        if (!(to == address(0) && from != _msgSender())) {
             require(!accountPaused(from), AccountIsPaused(from));
         }
         ERC20PausableUpgradeable._update(from, to, value);


### PR DESCRIPTION
## Audit finding N-08 — Code Improvements

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: notes)

### Changes
1. **Invert empty clawback branch** in `StablecoinUpgradeableV2._update` so the paused-from check is stated directly instead of living in an empty `if` / populated `else`.
2. **Add `__AccountPausable_init_unchained`** and have `__AccountPausable_init` call it, matching the OpenZeppelin upgradeable module pair convention.

### Notes
- No behavior change.
- **Stacked PR (1/3 Notes).** Base: `audit08-L03-reinitialize-version-guard` (L-03 / #18). Retarget toward `main` as the stack merges down.
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/57

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author