### PR TITLE
docs: N-09 correct inaccurate and misleading comments

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -5,11 +5,10 @@ import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Ini
 import {ContextUpgradeable} from "@openzeppelin-upgradeable/contracts/utils/ContextUpgradeable.sol";
 
 /**
- * @dev The following contract lets us halt activities for accounts that have been paused using the
- * `_pauseAccount` method and the same action can be reverted by using the `_unpauseAccount`
- * method. The state is stored at a custom storage location as per ERC7201. The modifiers in this
- * contract are used in the base `StablecoinUpgradeable` contract resulting in blocked actions for
- * specific accounts.
+ * @dev Halt activity for individual accounts that have been paused via `_pauseAccount` or
+ * `_tryPauseAccount`; the same action can be reverted with `_unpauseAccount`. State is stored at a
+ * custom storage location as per ERC-7201. Derived contracts such as `StablecoinUpgradeable` apply
+ * the modifiers here to block actions for specific accounts.
  *
  * @custom:security-contact bugs@ripple.com
  */
@@ -59,7 +58,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
     }
 
     /**
-     * @dev Modifier to make a function callable only when the acoount is paused.
+     * @dev Modifier to make a function callable only when the account is paused.
      *
      * Requirements:
      * - The account must already be paused.

--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -65,9 +65,9 @@ contract MultiSign {
     event DestinationCalled(address destination, bytes data, uint256 gasLimit);
 
     /**
-    * Default constructor to initialize the MultiSign contract.
-    * Signer addresses submitted to the contract should be ordered by their string values.
-    **/
+     * @dev Default constructor to initialize the MultiSign contract.
+     * Signer addresses must be strictly ascending by address value (numeric order).
+     */
     constructor (address[] memory _signers, uint8[] memory _weights, uint256 _quorum) {
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             EIP712DOMAIN_TYPEHASH,
@@ -90,7 +90,7 @@ contract MultiSign {
     }
 
     /**
-     * @dev Given an address of a signer, return the weight of it's signature that gets counted
+     * @dev Given an address of a signer, return the weight of its signature that gets counted
      * for this account.
      */
     function signerWeight(address signer) external view returns (uint8) {

--- a/contracts/StablecoinUpgradeable.sol
+++ b/contracts/StablecoinUpgradeable.sol
@@ -73,7 +73,7 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
      * @param to    The address that will be receiving the minted amount.
      * @param value The amount of tokens that are being minted to the account.
      *
-     * Emits a {Transfer} event with `source` set to the zero address.
+     * Emits a {Transfer} event with `from` set to the zero address.
      */
     function mint(address to, uint256 value) public virtual onlyRole(MINTER_ROLE) {
         _mint(to, value);
@@ -85,7 +85,7 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
      *
      * @param value The amount of tokens that are being burned from message sender's holdings.
      *
-     * Emits a {Transfer} event with `destination` set to the zero address.
+     * Emits a {Transfer} event with `to` set to the zero address.
      */
     function burn(uint256 value) public virtual onlyRole(BURNER_ROLE) {
         _burn(msg.sender, value);
@@ -98,39 +98,42 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
      * @param from  The address from which the tokens will be burned.
      * @param value The amount of tokens that will be burned.
      *
-     * Emits a {Transfer} event with `destination` set to the zero address.
+     * Emits a {Transfer} event with `to` set to the zero address.
      */
     function clawback(address from, uint256 value) public virtual onlyRole(CLAWBACKER_ROLE) {
         _burn(from, value);
     }
 
     /**
-     * Allow an authorized minter to pause the circulation of ERC20 tokens from all accounts.
+     * Allow an authorized pauser to pause the circulation of ERC20 tokens from all accounts.
      *
      * Requirements:
      * - The contract must not be paused.
+     * - The caller must have {PAUSER_ROLE}.
      */
     function pause() public virtual onlyRole(PAUSER_ROLE) {
         _pause();
     }
 
     /**
-     * Allow an authorized minter to resume/unpause the circulation of ERC20 tokens from all account.
+     * Allow an authorized pauser to resume/unpause the circulation of ERC20 tokens from all accounts.
      *
      * Requirements:
      * - The contract must be paused.
+     * - The caller must have {PAUSER_ROLE}.
      */
     function unpause() public virtual onlyRole(PAUSER_ROLE) {
         _unpause();
     }
 
     /**
-     * Allow an authorized minter to pause the circulation of ERC20 tokens from a specified account.
+     * Allow an authorized pauser to pause the circulation of ERC20 tokens from specified accounts.
      *
      * @param accounts An array of addresses that will be paused, restricting them from taking any value moving actions.
      *
      * Requirements:
      * - accounts in the {accounts} list should be unpaused
+     * - The caller must have {PAUSER_ROLE}.
      */
     function pauseAccounts(address[] calldata accounts) public virtual onlyRole(PAUSER_ROLE) {
         address lastAdd = address(0);
@@ -143,12 +146,13 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
     }
 
     /**
-     * Allow an authorized minter to resume/unpause the circulation of ERC20 tokens from a specified account.
+     * Allow an authorized pauser to resume/unpause the circulation of ERC20 tokens from a specified account.
      *
      * @param account The address that is being unpaused.
      *
      * Requirements:
      * - the {account} should be paused
+     * - The caller must have {PAUSER_ROLE}.
      */
     function unpauseAccount(address account) public virtual onlyRole(PAUSER_ROLE) {
         _unpauseAccount(account);

--- a/contracts/StablecoinUpgradeableV2.sol
+++ b/contracts/StablecoinUpgradeableV2.sol
@@ -36,20 +36,20 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
     }
 
     /**
-     * @dev This method is used to re-initialize the contract with values that we want to use to bootstrap and run things.
-     * The modifier reinitializer here helps us block initialization in the constructor so that we initialize value only
-     * when deploying the proxy and not the contract itself. The reinitializer also tracks how many times this method is
-     * called and it can only be called once.
+     * @dev Re-initialize a V1 proxy as V2 by wiring ERC-20 permit storage from the existing token name.
+     * `_disableInitializers` in the constructor blocks initialization of the implementation itself.
+     * `reinitializer(2)` advances the initializer version to 2 and ensures this path runs at most once.
+     * `_onlyInitializedV1` requires the proxy to already be at version 1 so a fresh (uninitialized)
+     * proxy cannot be advanced to version 2 and bricked.
      */
     function reinitialize() external _onlyInitializedV1 reinitializer(2) {
         __ERC20Permit_init(name());
     }
 
     /**
-     * @dev This method is used to initialize the contract with values that we want to use to bootstrap and run things.
-     * The modifier initializer here helps us block initialization in the constructor so that we initialize value only
-     * when deploying the proxy and not the contract itself. The initializer also tracks how many times this method is
-     * called and it can only be called once.
+     * @dev Initialize a fresh proxy directly as V2. `_onlyUninitialized` rejects proxies that are
+     * already initialized, and `reinitializer(2)` sets the initializer version to 2. Constructor
+     * initialization of the implementation is blocked by `_disableInitializers`.
      *
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
@@ -118,12 +118,14 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
     }
 
     /**
-     * An overridden method to add modifiers to check if the accounts being used to transfer are not frozen.
+     * @dev Sets `value` as the allowance of `spender` over `owner`'s tokens via a signature (ERC-2612).
+     * Overrides the parent to additionally require that `owner`, `spender`, and the caller are not
+     * account-paused and that the contract itself is not paused.
      *
-     * @param owner The address of the owner of the token.
-     * @param spender The address of the spender of the token.
-     * @param value The amount of tokens to be approved.
-     * @param deadline The deadline for the permit.
+     * @param owner The address of the owner of the tokens.
+     * @param spender The address of the spender receiving the allowance.
+     * @param value The amount of tokens to approve.
+     * @param deadline The deadline for the permit signature.
      * @param v The v value of the signature.
      * @param r The r value of the signature.
      * @param s The s value of the signature.


### PR DESCRIPTION
## Audit finding N-09 — Inaccurate Comments

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: notes)

### Changes
- `pause` / `unpause` / `pauseAccounts` / `unpauseAccount`: attribute action to `PAUSER_ROLE`, not minter.
- `mint` / `burn` / `clawback`: Transfer event params are `from` / `to`, not `source` / `destination`.
- `AccountPausableUpgradeable` contract docstring: clarify derived contracts use it; mention `_tryPauseAccount`; fix "acoount" typo.
- V2 `reinitialize` / `initialize`: correctly describe `reinitializer`, `_onlyInitializedV1` / `_onlyUninitialized`, and `_disableInitializers`.
- V2 `permit`: describe allowance (ERC-2612), not transfer.
- MultiSign constructor: addresses ordered numerically; `signerWeight` "it's" → "its".

### Notes
- Documentation-only; no behavior change.
- **Stacked PR (2/3 Notes).** Base: `audit08-N08-code-improvements` (N-08 / #19).
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/58

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author