### PR TITLE
docs: N-03 fix broken @inheritdoc and document V2 pauseAccounts

### DIFF
--- a/contracts/StablecoinUpgradeableV2.sol
+++ b/contracts/StablecoinUpgradeableV2.sol
@@ -94,7 +94,16 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
         ERC20PausableUpgradeable._update(from, to, value);
     }
 
-    // @inheritdoc StablecoinUpgradeable
+    /**
+     * @dev Pause the listed accounts. Unlike the V1 override, already-paused accounts are skipped
+     * via `_tryPauseAccount` rather than reverting, and an empty list reverts.
+     *
+     * @param accounts Sorted ascending list of addresses to pause.
+     *
+     * Requirements:
+     * - {accounts} must be non-empty and strictly ascending
+     * - The caller must have {PAUSER_ROLE}
+     */
     function pauseAccounts(address[] calldata accounts) public virtual
         override(StablecoinUpgradeable)
         onlyRole(PAUSER_ROLE)


### PR DESCRIPTION
## Audit finding N-03 — Missing Docstrings (partial)

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: notes)

### Scope
Only the high-signal portion of N-03:
- `StablecoinUpgradeableV2.pauseAccounts` used `// @inheritdoc`, which is **not** NatSpec. Parent docs require accounts to be unpaused; V2 uses `_tryPauseAccount` and allows already-paused accounts, so an explicit docstring is preferable to inheriting the wrong one.

Full missing-docstrings coverage (constants, private state, errors) is intentionally out of scope.

### Notes
- Documentation-only; no behavior change.
- **Stacked PR (3/3 Notes).** Base: `audit08-N09-inaccurate-comments` (N-09 / #20).
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/59

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author