### PR TITLE
refactor: N-01 named mapping params and N-02 indexed event parameters

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -28,13 +28,15 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
     }
 
     /**
-     * This event is emitted when an account is paused in the contract.
+     * @dev Emitted when an account is paused in the contract.
+     * @param account The account that was paused.
      */
-    event AccountPaused(address account);
+    event AccountPaused(address indexed account);
     /**
-     * This event is emitted when an account is unpaused in the contract.
+     * @dev Emitted when an account is unpaused in the contract.
+     * @param account The account that was unpaused.
      */
-    event AccountUnpaused(address account);
+    event AccountUnpaused(address indexed account);
 
     error AccountIsPaused(address account);
     error AccountIsNotPaused(address account);

--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -40,8 +40,8 @@ contract MultiSign {
      */
     uint256 public nonce;
     address[] private signersArr;
-    mapping (address => bool) private isSigner;
-    mapping (address => uint8) private weights;
+    mapping (address signer => bool) private isSigner;
+    mapping (address signer => uint8 weight) private weights;
 
     /**
      * @dev Event emitted when the state of the contract changes.
@@ -51,7 +51,7 @@ contract MultiSign {
      * @param weights The new array of weights of the signers.
      * @param quorum  The cumulative weight of all signatures should exceed or match this value.
      */
-    event SignersChanged(address account, address[] signers, uint8[] weights, uint256 quorum);
+    event SignersChanged(address indexed account, address[] signers, uint8[] weights, uint256 quorum);
 
     /**
      * @dev Event emitted when the destination contract is called with the provided calldata.
@@ -62,7 +62,7 @@ contract MultiSign {
      * @param gasLimit    The maximum amount of gas that can be consumed by the destination contract to execute the
      *                    calldata.
      */
-    event DestinationCalled(address destination, bytes data, uint256 gasLimit);
+    event DestinationCalled(address indexed destination, bytes data, uint256 gasLimit);
 
     /**
      * @dev Default constructor to initialize the MultiSign contract.


### PR DESCRIPTION
## Audit findings N-01 / N-02

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: notes)

### N-01
- `MultiSign.isSigner` / `weights` use named mapping parameters.

### N-02
- Index `AccountPaused` / `AccountUnpaused` `account`.
- Index `SignersChanged.account` and `DestinationCalled.destination`.
- Dynamic params stay unindexed.

### Notes
- **Stacked PR** on N-03 (#21).
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/60

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author