### PR TITLE
refactor: N-05 default inits, N-06 NatSpec, N-07 module init order

### DIFF
--- a/contracts/AccountPausableUpgradeable.sol
+++ b/contracts/AccountPausableUpgradeable.sol
@@ -50,6 +50,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
 
     /**
      * @dev Modifier to make a function callable only when the account is not paused.
+     * @param account The account that must not be paused.
      *
      * Requirements:
      * - The account must not already be paused.
@@ -61,6 +62,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
 
     /**
      * @dev Modifier to make a function callable only when the account is paused.
+     * @param account The account that must be paused.
      *
      * Requirements:
      * - The account must already be paused.
@@ -84,6 +86,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
 
     /**
      * @dev Pauses an account from circulating the ERC20 token.
+     * @param account The account to pause.
      *
      * Requirements:
      * - The account must not be paused.
@@ -96,6 +99,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
 
     /**
      * @dev Pauses an account from circulating the ERC20 token. And if the account is already paused, we don't revert.
+     * @param account The account to pause if not already paused.
      */
     function _tryPauseAccount(address account) internal virtual {
         AccountPausableStorage storage $ = _getAccountPausableStorage();
@@ -107,6 +111,7 @@ abstract contract AccountPausableUpgradeable is Initializable, ContextUpgradeabl
 
     /**
      * @dev Returns account to normal state.
+     * @param account The account to unpause.
      *
      * Requirements:
      * - The account must be paused.

--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -81,6 +81,9 @@ contract MultiSign {
     /**
      * @dev Default constructor to initialize the MultiSign contract.
      * Signer addresses must be strictly ascending by address value (numeric order).
+     * @param _signers Ordered signer addresses.
+     * @param _weights Per-signer signature weights, parallel to `_signers`.
+     * @param _quorum Cumulative weight required to execute.
      */
     constructor (address[] memory _signers, uint8[] memory _weights, uint256 _quorum) {
         DOMAIN_SEPARATOR = keccak256(abi.encode(
@@ -98,6 +101,7 @@ contract MultiSign {
 
     /**
      * @dev Returns the list of signer addresses in an array.
+     * @return The current signer addresses.
      */
     function signers() external view returns (address[] memory) {
         return signersArr;
@@ -106,6 +110,8 @@ contract MultiSign {
     /**
      * @dev Given an address of a signer, return the weight of its signature that gets counted
      * for this account.
+     * @param signer The signer address to query.
+     * @return The weight of `signer`, or 0 if not a signer.
      */
     function signerWeight(address signer) external view returns (uint8) {
         return weights[signer];
@@ -125,8 +131,8 @@ contract MultiSign {
         }
 
         // add new signers to map
-        uint256 signatureWeights = 0;
-        address lastAdd = address(0);
+        uint256 signatureWeights;
+        address lastAdd;
         uint256 newSignerArrLength = _signers.length;
         for (uint256 i = 0; i < newSignerArrLength; ++i) {
             require(_signers[i] > lastAdd, AddressesNotSorted());
@@ -148,6 +154,9 @@ contract MultiSign {
      * end of successful execution.
      * This method can be called by this contract only in order to verify that the signatures are
      * from existing signers with privilege to do so.
+     * @param _signers Ordered signer addresses.
+     * @param _weights Per-signer signature weights, parallel to `_signers`.
+     * @param _quorum Cumulative weight required to execute.
      */
     function setSigners(address[] memory _signers, uint8[] memory _weights, uint256 _quorum) external {
         require(msg.sender == address(this), OnlySelf());
@@ -159,6 +168,13 @@ contract MultiSign {
      * @dev This method is called by an EOA/funding account with the correct set of signatures to eventually
      * make a call to the `destination` with provided call data.
      * Example, calls to the ERC20 contract are made from this method for all MultiSign accounts.
+     * @param sigV Signature v components, ordered by recovered signer address.
+     * @param sigR Signature r components, parallel to `sigV`.
+     * @param sigS Signature s components, parallel to `sigV`.
+     * @param executor Address that must equal `msg.sender`.
+     * @param destination Contract that receives the call.
+     * @param gasLimit Gas stipend forwarded to `destination`.
+     * @param data Calldata executed against `destination`.
      */
     function execute(
         uint8[] memory sigV, bytes32[] memory sigR, bytes32[] memory sigS, address executor, address destination,
@@ -181,8 +197,8 @@ contract MultiSign {
             ))
         ));
 
-        uint256 signatureWeights = 0;
-        address lastAdd = address(0); // cannot have address(0) as an owner
+        uint256 signatureWeights;
+        address lastAdd; // cannot have address(0) as an owner (default)
         uint256 signaturesLength = sigV.length;
         for (uint256 i = 0; i < signaturesLength; ++i) {
             address recovered = ECDSA.recover(digest, sigV[i], sigR[i], sigS[i]);
@@ -198,8 +214,7 @@ contract MultiSign {
 
         require(destination.code.length > 0, DestinationNotContract());
 
-        bool success = false;
-        (success,) = destination.call{gas: gasLimit}(data);
+        (bool success,) = destination.call{gas: gasLimit}(data);
         emit DestinationCalled(destination, data, gasLimit);
         require(success, DestinationCallFailed());
     }

--- a/contracts/StablecoinProxy.sol
+++ b/contracts/StablecoinProxy.sol
@@ -10,11 +10,16 @@ import {ERC1967Proxy} from "node_modules/@openzeppelin/contracts/proxy/ERC1967/E
  **/
 contract StablecoinProxy is ERC1967Proxy {
 
+    /**
+     * @param implementation Address of the logic contract.
+     * @param _data Optional initialization calldata forwarded to the implementation.
+     */
     constructor (address implementation, bytes memory _data)  ERC1967Proxy(implementation, _data)  {
     }
 
     /**
      * @dev Returns the implementation address of the contract that executes a transaction.
+     * @return The current implementation address.
      */
     function getImplementation() public view returns (address) {
         return _implementation();

--- a/contracts/StablecoinUpgradeable.sol
+++ b/contracts/StablecoinUpgradeable.sol
@@ -56,14 +56,16 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
                         address pauser_, address clawbacker_)
         external virtual initializer
     {
+        // Module initializers first (uninterrupted), then role assignment.
         __ERC20_init(name_, symbol_);
         __UUPSUpgradeable_init();
         __AccessControl_init();
+        __ERC20Pausable_init();
+        __AccountPausable_init();
+
         _grantRole(DEFAULT_ADMIN_ROLE, admin_);
         _grantRole(MINTER_ROLE, minter_);
         _grantRole(UPGRADER_ROLE, upgrader_);
-        __ERC20Pausable_init();
-        __AccountPausable_init();
         _grantRole(PAUSER_ROLE, pauser_);
         _grantRole(CLAWBACKER_ROLE, clawbacker_);
     }
@@ -139,7 +141,7 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
      * - The caller must have {PAUSER_ROLE}.
      */
     function pauseAccounts(address[] calldata accounts) public virtual onlyRole(PAUSER_ROLE) {
-        address lastAdd = address(0);
+        address lastAdd;
         uint256 accountsLength = accounts.length;
         for (uint256 i = 0; i < accountsLength; ++i) {
             require(accounts[i] > lastAdd, AddressesNotSorted());
@@ -164,11 +166,15 @@ contract StablecoinUpgradeable is Initializable, ERC20Upgradeable, UUPSUpgradeab
     /**
      * An overridden method from {UUPSUpgradeable} which defines the permissions for authorizing an upgrade to a
      * new implementation.
+     * @param newImplementation The address of the candidate implementation contract.
      */
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyRole(UPGRADER_ROLE) {}
 
     /**
      * An overridden method to add modifiers to check if the accounts being used to transfer are not frozen.
+     * @param from The address tokens are moved from (zero on mint).
+     * @param to The address tokens are moved to (zero on burn).
+     * @param value The amount of tokens transferred.
      *
      * Requirements:
      * - the {from} account should not be paused/frozen

--- a/contracts/StablecoinUpgradeableV2.sol
+++ b/contracts/StablecoinUpgradeableV2.sol
@@ -69,16 +69,18 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
 
     function _initializeV2Params(string memory name_, string memory symbol_, address admin_, address upgrader_,
         address pauser_, address clawbacker_) internal onlyInitializing {
+        // Module initializers first (uninterrupted; ERC20Permit with the other ERC20 modules), then roles.
         __ERC20_init(name_, symbol_);
+        __ERC20Permit_init(name_);
         __UUPSUpgradeable_init();
         __AccessControl_init();
-        _grantRole(DEFAULT_ADMIN_ROLE, admin_);
-        _grantRole(UPGRADER_ROLE, upgrader_);
         __ERC20Pausable_init();
         __AccountPausable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+        _grantRole(UPGRADER_ROLE, upgrader_);
         _grantRole(PAUSER_ROLE, pauser_);
         _grantRole(CLAWBACKER_ROLE, clawbacker_);
-        __ERC20Permit_init(name_);
     }
 
     /// @inheritdoc StablecoinUpgradeable
@@ -108,7 +110,7 @@ contract StablecoinUpgradeableV2 is ERC20PermitUpgradeable, StablecoinUpgradeabl
         override(StablecoinUpgradeable)
         onlyRole(PAUSER_ROLE)
     {
-        address lastAdd = address(0);
+        address lastAdd;
         uint256 accountsLength = accounts.length;
         require(accountsLength > 0, NoAccountsToPause());
         for (uint256 i = 0; i < accountsLength; ++i) {


### PR DESCRIPTION
## Audit findings N-05 / N-06 / N-07

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: notes)

### N-05
Drop redundant default initializations (signatureWeights, lastAdd, success).

### N-06
Add missing @param/@return on MultiSign, AccountPausable, StablecoinProxy, and V1 _authorizeUpgrade/_update.

### N-07
Run module initializers as an uninterrupted prologue, then grant roles. In V2, __ERC20Permit_init runs with the other ERC20 modules before role assignment.

### Notes
- No functional change expected (N-07 finding states no defect).
- Stacked PR on N-04 (#23).
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/62

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author