### PR TITLE
fix(proxy): L-02 remove getImplementation to free reserved selector

### DIFF
--- a/contracts/StablecoinProxy.sol
+++ b/contracts/StablecoinProxy.sol
@@ -17,12 +17,7 @@ contract StablecoinProxy is ERC1967Proxy {
     constructor (address implementation, bytes memory _data)  ERC1967Proxy(implementation, _data)  {
     }
 
-    /**
-     * @dev Returns the implementation address of the contract that executes a transaction.
-     * @return The current implementation address.
-     */
-    function getImplementation() public view returns (address) {
-        return _implementation();
-    }
-
+    // No own functions: every selector is delegated so future implementations are never shadowed.
+    // Read the implementation off-chain via the ERC-1967 slot (eth_getStorageAt) or on-chain via
+    // ERC1967Utils.getImplementation().
 }


### PR DESCRIPTION
## Audit finding L-02 — remaining portion

Earlier PR (#17) only renamed the shadowed constructor parameter and intentionally kept `getImplementation`.

This finishes L-02 by **removing** `StablecoinProxy.getImplementation()` so selector `0xaaf10f42` is no longer answered by the proxy.

### Notes
- ABI break for callers of `getImplementation` — intentional; use ERC-1967 slot / `ERC1967Utils.getImplementation()` instead.
- **Stacked** on N-05 tip (#25).
- Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/63

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author