### PR TITLE
fix(multisign): L-01 require signer and weight arrays to have equal length

### DIFF
--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -99,6 +99,7 @@ contract MultiSign {
 
     // Note that signers_ must be strictly increasing, in order to prevent duplicates
     function setSigners_(address[] memory _signers, uint8[] memory _weights, uint256 _quorum) private {
+        require(_signers.length == _weights.length, "Signers and weights arrays must have the same length.");
         require(_signers.length <= 32, "Contract allows adding up to 32 signers only.");
         require(_quorum > 0, "Quorum cannot be 0.");
 


### PR DESCRIPTION
## Audit finding L-01 — MultiSign only

Source: OpenZeppelin #08 Retainer — Stablecoin Contracts Audit (severity: low)

### Fix
`require(_signers.length == _weights.length, ...)` at the start of `setSigners_`.

### Scope
**`contracts/MultiSign.sol` only.** Stacked PR 1/5 of the MultiSign-only audit response.

Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/64