### PR TITLE
docs(multisign): N-09 constructor ordering and signerWeight wording

### DIFF
--- a/contracts/MultiSign.sol
+++ b/contracts/MultiSign.sol
@@ -65,9 +65,9 @@ contract MultiSign {
     event DestinationCalled(address destination, bytes data, uint256 gasLimit);
 
     /**
-    * Default constructor to initialize the MultiSign contract.
-    * Signer addresses submitted to the contract should be ordered by their string values.
-    **/
+     * @dev Default constructor to initialize the MultiSign contract.
+     * Signer addresses must be strictly ascending by address value (numeric order).
+     */
     constructor (address[] memory _signers, uint8[] memory _weights, uint256 _quorum) {
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             EIP712DOMAIN_TYPEHASH,
@@ -90,7 +90,7 @@ contract MultiSign {
     }
 
     /**
-     * @dev Given an address of a signer, return the weight of it's signature that gets counted
+     * @dev Given an address of a signer, return the weight of its signature that gets counted
      * for this account.
      */
     function signerWeight(address signer) external view returns (uint8) {


### PR DESCRIPTION
## Audit finding N-09 — MultiSign only

Constructor address ordering (numeric) and signerWeight "it's" → "its".

### Scope
**MultiSign.sol only.** Other-contract N-09 doc fixes deferred. Stacked 2/5.

Mirrors GitLab MR https://gitlab.com/ripple/stablecoin/issuer/stablecoin-contracts/-/merge_requests/65